### PR TITLE
Prefer system installation of UHD library

### DIFF
--- a/src/UHDBindings.jl
+++ b/src/UHDBindings.jl
@@ -21,9 +21,15 @@ end
 # --- Artifact for LibUHD 
 # ---------------------------------------------------- 
 # init globals and lib path
+# Prefer system libraries over artifacts
 using Pkg.Artifacts;
-const libUHD_rootpath = artifact"libUHD";
-const libUHD = joinpath(libUHD_rootpath, "libuhd.so");
+const LibUHD_system_h = dlopen("libuhd", false);
+if isnothing(LibUHD_system_h)
+	const libUHD_rootpath = artifact"libUHD";
+	const libUHD = joinpath(libUHD_rootpath, "libuhd.so");
+else
+	const libUHD = dlpath(LibUHD_local_h)
+end
 
 # ---------------------------------------------------- 
 # --- Common configuration and structures 

--- a/src/UHDBindings.jl
+++ b/src/UHDBindings.jl
@@ -28,7 +28,7 @@ if isnothing(LibUHD_system_h)
 	const libUHD_rootpath = artifact"libUHD";
 	const libUHD = joinpath(libUHD_rootpath, "libuhd.so");
 else
-	const libUHD = dlpath(LibUHD_local_h)
+	const libUHD = dlpath(LibUHD_system_h)
 end
 
 # ---------------------------------------------------- 

--- a/src/UHDBindings.jl
+++ b/src/UHDBindings.jl
@@ -23,12 +23,12 @@ end
 # init globals and lib path
 # Prefer system libraries over artifacts
 using Pkg.Artifacts;
-const LibUHD_system_h = dlopen("libuhd", false);
-if isnothing(LibUHD_system_h)
+const libUHD_system_h = dlopen("libuhd", false);
+if isnothing(libUHD_system_h)
 	const libUHD_rootpath = artifact"libUHD";
 	const libUHD = joinpath(libUHD_rootpath, "libuhd.so");
 else
-	const libUHD = dlpath(LibUHD_system_h)
+	const libUHD = dlpath(libUHD_system_h)
 end
 
 # ---------------------------------------------------- 

--- a/src/UHDBindings.jl
+++ b/src/UHDBindings.jl
@@ -23,7 +23,7 @@ end
 # init globals and lib path
 # Prefer system libraries over artifacts
 using Pkg.Artifacts;
-const libUHD_system_h = dlopen("libuhd", false);
+libUHD_system_h = dlopen("libuhd", false;throw_error=false);
 if isnothing(libUHD_system_h)
 	const libUHD_rootpath = artifact"libUHD";
 	const libUHD = joinpath(libUHD_rootpath, "libuhd.so");


### PR DESCRIPTION
Pretty simple change to fix potential Boost issues mentioned in #3. This change will pickup the system install of `libuhd` over Julia artifacts. Checked it works with system packages on my system, I can't test to make sure it still works with artifacts.

Happy to accept any changes, I'm still very much a Julia beginner.