### PR TITLE
Error checking in populateBuffer!

### DIFF
--- a/src/Bindings.jl
+++ b/src/Bindings.jl
@@ -55,6 +55,7 @@ mutable struct UHDRx
 	packetSize::Csize_t;
 	released::Int;
     nbAntennaRx::Int;
+    checkErrors::Bool;
 end
 
 # --- Structure with pointer reference

--- a/src/UHDBindings.jl
+++ b/src/UHDBindings.jl
@@ -297,5 +297,14 @@ export print;
 export close;
 export getBufferSize
 
+# ----------------------------------------------------
+# --- Error handling
+# ----------------------------------------------------
+abstract type UHDException <: Exception end
+struct LateCommandException <: UHDException end
+struct BrokenChainException <: UHDException end
+struct OverflowException <: UHDException end
+struct AlignmentException <: UHDException end
+struct BadPacketException <: UHDException end
 
 end # moduled # module


### PR DESCRIPTION
Added an option to raise exceptions if received packet metadata indicates an error (see #10). This is disabled by default if the streamer is configured in continuous mode, to avoid breaking existing code that can ignore overflow errors and doesn't care about the exact number of samples received.

The exceptions are not exported to avoid adding generic names such as OverflowException to the global namespace.
